### PR TITLE
Fix restoring GOBIN

### DIFF
--- a/bin/gvp
+++ b/bin/gvp
@@ -53,7 +53,7 @@ case "$1" in
     GVP_OLD_GOPATH=$GOPATH
     GVP_OLD_GOBIN=$GOBIN
     GVP_OLD_PATH=$PATH
-    export GVP_OLD_GOPATH PATH
+    export GVP_OLD_GOPATH GVP_OLD_GOBIN PATH
 
     GVP_NAME=$(pwd | sed -E "s/^.*\/(.*)$/\\1/")
     GOBIN="$GVP_DIR/bin":$GOBIN
@@ -66,7 +66,7 @@ case "$1" in
   "out")
     if [[ -z $GVP_NAME ]]; then return; fi
 
-    GOBIN=$GVP_OLD_BIN_PATH
+    GOBIN=$GVP_OLD_GOBIN
     GOPATH=$GVP_OLD_GOPATH
     PATH=$GVP_OLD_PATH
 


### PR DESCRIPTION
`GOBIN` wasn't being remembered when calling `in`, thus wasn't being restored when `out` is called.

In the current branch, running the tests with a non-empty `GOBIN` fails:

```
inkel@lookfar ~/dev/gvp (master) ↩
↪ GOBIN=/tmp/bin make test
cd test && ./run_all_tests.sh
>> Now running all tests
>> Current test: init_in_and_out_test.sh
>> Local GOPATH set.
>> Reverted to system GOPATH.
test #8 "echo " failed:
    expected "/tmp/bin"
    got nothing
1 of 9 examples tests failed in 0s.
>> All Done
>> Build status: failing
make: *** [test] Error 1
```

The reason is that `gvp in` isn't exporting `GVP_OLD_GOBIN`, and `gvp out` restores `GOBIN` to the contents of the undefined variable `GVP_OLD_BIN_PATH`. The tests weren't failing because normally `GOBIN` is empty. With this change, now all tests passes:

```
inkel@lookfar ~/dev/gvp (restore-gobin) ↩
↪ GOBIN=/tmp/bin make test
cd test && ./run_all_tests.sh
>> Now running all tests
>> Current test: init_in_and_out_test.sh
>> Local GOPATH set.
>> Reverted to system GOPATH.
>> All 9 examples tests passed in 1s.
>> All Done
>> Build status: passing
inkel@lookfar ~/dev/gvp (restore-gobin) ↩
↪ make test
cd test && ./run_all_tests.sh
>> Now running all tests
>> Current test: init_in_and_out_test.sh
>> Local GOPATH set.
>> Reverted to system GOPATH.
>> All 9 examples tests passed in 0s.
>> All Done
>> Build status: passing
```
