### PR TITLE
`gvp init` should create typical $GOPATH subdirectories

### DIFF
--- a/bin/gvp
+++ b/bin/gvp
@@ -38,7 +38,8 @@ fi
 
 case "$1" in
   "init")
-    mkdir .godeps;;
+    mkdir -p .godeps/{src,pkg,bin}
+    ;;
   "version")
     echo ">> gvp v0.1.0"
     ;;


### PR DESCRIPTION
otherwise, `go get` does not build libraries in pkg automatically.
