### PR TITLE
fixes incorrect usage of $GOBIN

### DIFF
--- a/bin/gvp
+++ b/bin/gvp
@@ -59,9 +59,9 @@ case "$1" in
     export GVP_OLD_GOPATH GVP_OLD_GOBIN PATH
 
     GVP_NAME=$(pwd | sed -E "s/^.*\/(.*)$/\\1/")
-    GOBIN="$GVP_DIR/bin":$GOBIN
-    GOPATH=$GVP_DIR:$PWD
-    PATH="$GVP_DIR/bin":$PATH
+    GOBIN="$GVP_DIR/bin"
+    GOPATH="$GVP_DIR:$PWD"
+    PATH="$GOBIN:$PATH"
 
     export GOBIN GOPATH GVP_NAME PATH
     echo ">> Local GOPATH set."

--- a/test/init_in_and_out_test.sh
+++ b/test/init_in_and_out_test.sh
@@ -14,7 +14,7 @@ ORIGINAL_PATH=$PATH
 source $GVP in
 
 assert "echo $GOPATH" "$PWD/.godeps:$PWD"
-assert "echo $GOBIN"  "$PWD/.godeps/bin:$ORIGINAL_GOBIN"
+assert "echo $GOBIN"  "$PWD/.godeps/bin"
 assert "echo $PATH"   "$PWD/.godeps/bin:$ORIGINAL_PATH"
 
 


### PR DESCRIPTION
gobin in this case should _only_ point
to the .godeps/bin directory, otherwise you end up with

```
.godeps /
    bin /
    bin: / <-- where binaries are actually placed by go get
```

when it should obviously only be in `.godeps/bin`.

I also fixed some oddities regarding setting things to be exported.
