### PR TITLE
Fixes issue where `gvp in CMD` breaks args

### DIFF
--- a/bin/gvp
+++ b/bin/gvp
@@ -67,7 +67,7 @@ case "$1" in
     echo ">> Local GOPATH set."
 
     if [[ -n $2 ]]; then
-      eval ${@:2}
+      "${@:2}"
     fi
     ;;
   "out")


### PR DESCRIPTION
Running `gvp in CMD` breaks the arguments given to `CMD`. For example, if you try to pass a filename with spaces in it, the command will receive the filename broken up into separate arguments, when it should be just one (assuming you escape it correctly).

I'm not sure of the other ramifications of the change, but it fixes this issue.