### PR TITLE
CLI simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,15 @@ $ make install
 Since `gvp` is a script and runs in a child environment of your shell, the latter will not take the env changes unless you `source` them.
 
 ```shell
-$ gvp init
-$ source gvp in
-$ source gvp out
+$ source gvp
 ```
 
 ### Commands
 
 ```shell
-init    Creates the .godeps directory
-in      Modifies GOPATH, GOBIN and PATH to use the .godeps
-out     Restores the previous GOPATH, GOBIN and PATH.
-version   outputs version information.
-help      prints this message.
+source gvp    Modifies GOPATH, GOBIN and PATH to use the .godeps directory.
+gvp version   Outputs version information.
+gvp help      Prints this message.
 ```
 
 ### PLugins

--- a/bin/gvp
+++ b/bin/gvp
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 usage() {
 cat << EOF
 usage: gvp [COMMAND]
@@ -16,70 +17,33 @@ SYNOPSIS
 USAGE
     Since gvp is a script, env changes will not happen unless you source them.
 
-      $ gvp init
-      $ source gvp in
-      $ source gvp out
+      $ source gvp
 
 COMMANDS
-    init      Creates the .godeps directory.
-    in        Modifies GOPATH and GOBIN to use the .godeps directory and sets the GVP_NAME variable.
-              This can also be used to execute a comand in the environment without sourcing it.
-              For example: "gvp in go build"
-    out       Restores the previous GOPATH and GOBIN and unsets GVP_NAME.
-    version   outputs version information.
-    help      prints this message.
+    source gvp      Modifies GOPATH and GOBIN to use the .godeps directory.
+    gvp version     Outputs version information.
+    gvp help        Prints this message.
 EOF
 }
 
-if [[ "$1" != "in" && "$#" -ne 1 ]]; then
-  usage
-  exit 1
-fi
-
-case "$1" in
+case "${1:-"in"}" in
   "init")
+    echo ">> This command is deprecated, just run 'source gvp'."
     mkdir -p .godeps/{src,pkg,bin}
     ;;
   "version")
     echo ">> gvp v0.1.0"
     ;;
   "in")
-    if [[ -n $GVP_NAME ]]; then kill -INT $$; fi
+    mkdir -p .godeps/{src,pkg,bin}
 
     GVP_DIR="$(pwd)/.godeps"
-
-    if [[ ! -d $GVP_DIR ]]; then
-      echo '>> Directory .godeps not found. Run `gvp init` first.'
-      kill -INT $$
-    fi
-
-    GVP_OLD_GOPATH=$GOPATH
-    GVP_OLD_GOBIN=$GOBIN
-    GVP_OLD_PATH=$PATH
-    export GVP_OLD_GOPATH GVP_OLD_GOBIN PATH
-
-    GVP_NAME=$(basename $(pwd))
     GOBIN="$GVP_DIR/bin"
     GOPATH="$GVP_DIR:$PWD"
     PATH="$GOBIN:$PATH"
 
     export GOBIN GOPATH GVP_NAME PATH
     echo ">> Local GOPATH set."
-
-    if [[ -n $2 ]]; then
-      eval ${@:2}
-    fi
-    ;;
-  "out")
-    if [[ -z $GVP_NAME ]]; then kill -INT $$; fi
-
-    GOBIN=$GVP_OLD_GOBIN
-    GOPATH=$GVP_OLD_GOPATH
-    PATH=$GVP_OLD_PATH
-
-    export PATH GOPATH GOBIN
-    unset GVP_OLD_GOPATH GVP_OLD_GOBIN GVP_OLD_PATH GVP_NAME
-    echo ">> Reverted to system GOPATH."
     ;;
   "help")
     usage
@@ -93,8 +57,8 @@ case "$1" in
       gvp-$plugin $@ &&
       exit
     else
+      echo ">> Unknown command."
       usage && exit 1
     fi
     ;;
-
 esac

--- a/test/init_in_and_out_test.sh
+++ b/test/init_in_and_out_test.sh
@@ -5,25 +5,22 @@ GVP=../bin/gvp
 ## gvp init should create a .godeps/ directory.
 assert_raises "$GVP init"
 assert_raises "[ -d .godeps ]"
+## Cleanup
+rm -rf .godeps
 
-## source gvp in should change the original GOPATH and associated Env variables.
+## source gvp in should change the original GOPATH and associated Env variables
+## as well as creating a .godeps directory 
 ORIGINAL_GOPATH=$GOPATH
 ORIGINAL_GOBIN=$GOBIN
 ORIGINAL_PATH=$PATH
 
 source $GVP in
 
+assert_raises "[ -d .godeps ]"
 assert "echo $GOPATH" "$PWD/.godeps:$PWD"
 assert "echo $GOBIN"  "$PWD/.godeps/bin"
 assert "echo $PATH"   "$PWD/.godeps/bin:$ORIGINAL_PATH"
 
-
-### source gvp out should return env variables back to original values.
-source $GVP out
-
-assert "echo $GOPATH" "$ORIGINAL_GOPATH"
-assert "echo $GOBIN"  "$ORIGINAL_GOBIN"
-assert "echo $PATH"   "$ORIGINAL_PATH"
 
 ## Cleanup
 rm -rf .godeps


### PR DESCRIPTION
This PR simplifies the command line interface for gvp.

Main points are:
- It deprecates the `in` command so simply calling `source gvp` defaults to setting up environment variables, it's the main use case, so it makes sense to make the command briefer.
- Eliminates the `out` command, since if you need to change your `GOPATH` the aim will be to work on the context of a new project, you can simply run `source gvp` to set up the env for that project.
- Eliminates the `source gvp in <command>` function that's used to run a single command in the context of the local Go environment, my experience is that you very rarely will only run one command, so `source gvp` also takes care of this use case.

I'd like confirmation from users that these simplifications won't mess up their workflow, anybody has any thoughts? 
