### PR TITLE
prepending to old GOPATH instead of clobbering. addresses #18

### DIFF
--- a/bin/gvp
+++ b/bin/gvp
@@ -39,7 +39,7 @@ case "${1:-"in"}" in
 
     GVP_DIR="$(pwd)/.godeps"
     GOBIN="$GVP_DIR/bin"
-    GOPATH="$GVP_DIR:$PWD"
+    GOPATH="$GVP_DIR:$PWD:$GOPATH"
     PATH="$GOBIN:$PATH"
 
     export GOBIN GOPATH GVP_NAME PATH

--- a/test/init_in_and_out_test.sh
+++ b/test/init_in_and_out_test.sh
@@ -17,7 +17,7 @@ ORIGINAL_PATH=$PATH
 source $GVP in
 
 assert_raises "[ -d .godeps ]"
-assert "echo $GOPATH" "$PWD/.godeps:$PWD"
+assert "echo $GOPATH" "$PWD/.godeps:$PWD:$ORIGINAL_GOPATH"
 assert "echo $GOBIN"  "$PWD/.godeps/bin"
 assert "echo $PATH"   "$PWD/.godeps/bin:$ORIGINAL_PATH"
 


### PR DESCRIPTION
Seems like a good idea to me - maybe consider adding a `gvp clobber` command retaining the old functionality.