### PR TITLE
Create a soft link for "bin" folder.

### DIFF
--- a/bin/gvp
+++ b/bin/gvp
@@ -30,12 +30,14 @@ case "${1:-"in"}" in
   "init")
     echo ">> This command is deprecated, just run 'source gvp'."
     mkdir -p .godeps/{src,pkg,bin}
+    ln -s .godeps/bin bin
     ;;
   "version")
     echo ">> gvp v0.2.0"
     ;;
   "in")
     mkdir -p .godeps/{src,pkg,bin}
+    ln -s .godeps/bin bin
 
     GVP_DIR="$(pwd)/.godeps"
     GOBIN="$GVP_DIR/bin"


### PR DESCRIPTION
When using command "go install package_name",the executable will be put into ".godeps/bin" folder.it would be nice to have a soft link in your main directory.