### PR TITLE
Avoid adding : to GOPATH if it was unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
 ## Go Versioning Packager [![Build Status](https://travis-ci.org/pote/gvp.png?branch=master)](https://travis-ci.org/pote/gvp) [![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.3.0/dist/gratipay.svg)](https://gratipay.com/pote/)
 
-gvp stands for Go Versioning Packager and is based on [gst](http://github.com/tonchis/gst), a similar tool that provides dependency isolation for Ruby gems.
+gvp stands for Go Versioning Packager and is based on [gst][gst] a similar tool that provides dependency isolation for Ruby gems.
 
 The tool modifies your `GOPATH` to point to a local `.godeps/` directory so that you can keep the dependencies of your project isolated there, it also modifies `GOBIN` and `PATH` to include the new `GOPATH/bin` directory.
 
-gvp is a companion tool to [gpm](http://github.com/pote/gpm) but both tools can be used independently from each other.
+gvp is a companion tool to [gpm][gpm] but both tools can be used independently from each other.
 
-#### Example usage: Go Dependency Management and Vendoring with [gpm](https://github.com/pote/gpm) + gvp:
+#### Example usage: Go Dependency Management and Vendoring with [gpm][gpm] + gvp:
 
 ![gpm + gvp usage](https://raw.github.com/pote/gpm/master/gpm_install.gif)
 
+### Installation
 
-### Install via Homebrew
+#### Install in *nix (preferred method)
+
+```bash
+$ git clone https://github.com/pote/gvp.git && cd gvp
+$ git checkout v0.2.1 # You can ignore this part if you want to install HEAD.
+$ ./configure
+$ make install
+```
+
+#### Install via Homebrew
 
 ```bash
 $ brew install gvp
 ```
 
-### Install in *nix (preferred method)
-
-```bash
-$ git clone https://github.com/pote/gvp.git && cd gvp
-$ git checkout v0.3.0 # You can ignore this part if you want to install HEAD.
-$ ./configure
-$ make install
-```
 
 ### Usage
 
@@ -49,19 +51,28 @@ COMMANDS
     gvp out         Return the prompt to normal
 ```
 
-### PLugins
+### Using with [autoenv][autoenv]
 
-As of [v0.1.0](https://github.com/pote/gvp/releases/tag/v0.1.0) gvp includes a plugin system very much similar to [the one in gpm](https://github.com/pote/gpm#plugins).
+Simply run:
+```
+cd /path/to/project
+touch .env
+echo "source /path/to/gvp" > .env
+```
+
+### Plugins
+
+As of [v0.1.0][v0.1.0] gvp includes a plugin system very much similar to [the one in gpm][gpm-plugins].
 
 The way gvp plugin work is simple: whenever an unknown command is passed into gvp it will look for an executable in your $PATH called gvp-<command> and if it exists it will run it while passing all extra arguments to it, simple yet powerful.
 
 This brings a lot to the table: plugins can be written in anything, they can be Go binaries, bash scripts, Ruby gems, Python packages, you name it. gvp wants to make it easy for you to extend it. :)
 
-If you happen to write a plugin for gvp: please open [an issue](https://github.com/pote/gvp) so we can compile a list of useful plugins as well as add them to the [gpm homebrew tap](https://github.com/pote/homebrew-gpm_plugins) so users can install them easily.
+If you happen to write a plugin for gvp: please open [an issue][issues] so we can compile a list of useful plugins as well as add them to the [gpm homebrew tap](https://github.com/pote/homebrew-gpm_plugins) so users can install them easily.
 
 ### Why?
 
-Dependencies of multiple Go projects are by far easier to handle in isolation, using plain [gpm](http://github.com/pote/gpm)
+Dependencies of multiple Go projects are by far easier to handle in isolation, using plain [gpm][gpm]
 to handle your dependencies means that you are forced to run it again every time you work on a new project, this can get old
 quickly.
 
@@ -71,3 +82,10 @@ your system which will conflict in versioning across your different projects.
 
 If for some reason you need to ship your repository with its dependencies included this is also of help, but including a
 `Godeps` file to use with gpm will probably be your best option.
+
+[autoenv]: https://github.com/kennethreitz/autoenv
+[v0.1.0]: https://github.com/pote/gvp/releases/tag/v0.1.0
+[gpm]: https://github.com/pote/gpm
+[gpm-plugins]: https://github.com/pote/gpm#plugins
+[gst]: https://github.com/tonchis/gst
+[issues]: https://github.com/pote/gvp/issues

--- a/bin/gvp
+++ b/bin/gvp
@@ -32,7 +32,7 @@ EOF
 # Arguments: none
 # Returns (echoes): current prompt
 function current_prompt() {
-    echo $PS1
+    echo "$PS1"
 }
 
 # Description: store the current prompt as a backup in as many places as we can!
@@ -46,27 +46,27 @@ function store_current_prompt() {
 # Arguments: prompt to store
 # Returns (echoes): none
 function store_prompt() {
-    PROMPT_MANIPULATION_OLD=$1
+    PROMPT_MANIPULATION_OLD="$1"
     export PROMPT_MANIPULATION_OLD
     # env works where export doesn't if you spawn another process
-    env PROMPT_MANIPULATION_OLD=$1 > /dev/null
+    env PROMPT_MANIPULATION_OLD="$1" > /dev/null
     # store locally in case environment is manipulated during run
-    prompt_manipulation_old=$1
+    prompt_manipulation_old="$1"
 }
 
 # Description: The inverse function of store_prompt, deletes all stored variables
 # Arguments: none
 # Returns (echoes): none
 function unstore_prompt() {
-    unset '$prompt_manipulation_old'
-    unset '$PROMPT_MANIPULATION_OLD'
+    unset prompt_manipulation_old
+    unset PROMPT_MANIPULATION_OLD
 }
 
 # Description: Prefixes the user's shell prompt with a given string.
 # Arguments: string to put in front of the prompt.
 # Returns (echoes): none
 function prefix_prompt() {
-    PS1=$1$PS1
+    PS1="$1$PS1"
 }
 
 # Description: Reset the prompt to whatever it was before your script ran.
@@ -75,13 +75,13 @@ function prefix_prompt() {
 # Arguments: none
 # Returns (echoes): none
 function reset_prompt() {
-    if [ -z "$PROMPT_MANIPULATION_OLD" ] && [ -z "$old" ]; then
+    if [ -z "$PROMPT_MANIPULATION_OLD" ] && [ -z "$prompt_manipulation_old" ]; then
         echo "[ERROR] There was no old prompt to reset to!"
     elif [ -n "$prompt_manipulation_old" ]; then
-        PS1=$prompt_manipulation_old
+        PS1="$prompt_manipulation_old"
         export PS1
     elif [ -n "$PROMPT_MANIPULATION_OLD" ]; then
-        PS1=$PROMPT_MANIPULATION_OLD
+        PS1="$PROMPT_MANIPULATION_OLD"
         export PS1
     fi
     unstore_prompt
@@ -113,7 +113,7 @@ function gvp() {
 
         GVP_DIR="$(pwd)/.godeps"
         GOBIN="$GVP_DIR/bin"
-        GOPATH="$GVP_DIR:$PWD:$GOPATH"
+        GOPATH="$GVP_DIR:$PWD${GOPATH:+:}$GOPATH"
         PATH="$GOBIN:$PATH"
 
         export GOBIN GOPATH GVP_NAME PATH
@@ -133,7 +133,7 @@ function gvp() {
         then
             plugin=$1 &&
                 shift     &&
-                gvp-$plugin $@ &&
+                gvp-"$plugin" "$@" &&
                 exit
         else
             echo ">> Unknown command."

--- a/test/init_in_and_out_test.sh
+++ b/test/init_in_and_out_test.sh
@@ -18,7 +18,7 @@ original_PATH=$PATH
 . "$gvp"
 
 assert_raises "[ -d .godeps ]"
-assert "echo $GOPATH" "$PWD/.godeps:$PWD:$original_GOPATH"
+assert "echo $GOPATH" "$PWD/.godeps:$PWD${original_GOPATH:+:}$original_GOPATH"
 assert "echo $GOBIN"  "$PWD/.godeps/bin"
 assert "echo $PATH"   "$PWD/.godeps/bin:$original_PATH"
 

--- a/test/init_in_and_out_test.sh
+++ b/test/init_in_and_out_test.sh
@@ -4,7 +4,7 @@
 gvp=../bin/gvp
 
 ## gvp init should create a .godeps/ directory.
-assert_raises "$GVP init"
+assert_raises "$gvp init"
 assert_raises "[ -d .godeps ]"
 ## Cleanup
 rm -rf .godeps


### PR DESCRIPTION
This avoids adding a `:` to `GOPATH` if it was unset to begin with.  As mentioned in https://github.com/pote/gvp/issues/39, a recent change (go 1.5) causes `source gvp` to fail if `GOPATH` was unset.